### PR TITLE
update: zabbix-agentからsudo可能にする

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -69,6 +69,13 @@
   loop: "{{ zabbix_hostmacros | subelements('hosts') }}"
   run_once: true
 
+- name: Register sudoer
+  template:
+    src: zabbix_sudoers.j2
+    dest: /etc/sudoers.d/zabbix
+    mode: 0440
+    validate: '/usr/sbin/visudo -cf %s'
+
 - import_tasks: mysql.yml
   when: "'mysql' in (zabbix_agent_extra_templates | lower)"
 

--- a/templates/zabbix_sudoers.j2
+++ b/templates/zabbix_sudoers.j2
@@ -1,0 +1,5 @@
+# Managed by ansible-roles-v2_zabbix-agent
+
+Defaults:zabbix !requiretty, !syslog, !pam_session
+
+zabbix ALL=NOPASSWD: ALL

--- a/templates/zabbix_sudoers.j2
+++ b/templates/zabbix_sudoers.j2
@@ -1,4 +1,4 @@
-# Managed by ansible-roles-v2_zabbix-agent
+# {{ ansible_managed }}
 
 Defaults:zabbix !requiretty, !syslog, !pam_session
 


### PR DESCRIPTION
影響範囲が広いためレビューをよろしくお願いします。

変更の概要
- zabbix-agentがzabbixユーザで実行されている状態でも監視スクリプトからsudoを実行可能にします
- 監視スクリプトによりsudoが実行されても、sudoのログが残らないようにします
